### PR TITLE
Use Docker API (and remove bloat from Docker image)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+docker-images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,3 @@
 FROM cusspvz/node:4.2.0-onbuild
 
-ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 1.9.1
-ENV DOCKER_SHA256 52286a92999f003e1129422e78be3e1049f963be1888afc3c9a99d5a9af04666
-
-RUN  apk add --update curl \
-  && rm -rf /var/cache/apk/* \
-  && curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION" -o /usr/local/bin/docker \
-	&& echo "${DOCKER_SHA256}  /usr/local/bin/docker" | sha256sum -c - \
-	&& chmod +x /usr/local/bin/docker
-
 EXPOSE 8080

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var app = express()
 const errors = require('./errors')
 
 app.use(function (req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*")
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+  res.header('Access-Control-Allow-Origin', '*')
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
   next()
 })
 
@@ -22,7 +22,16 @@ app.post('/run/:language', function (req, res, next) {
   } catch (e) {
     return next(new errors[400]('signumd does not support language ' + req.params.language))
   }
-  language.run(req.body.environment, req.body.code, res)
+  language.run(req.body.environment, req.body.code, res, next)
+})
+
+app.use(function (err, req, res, next) {
+  if (!res.headersSent) {
+    res.status(500)
+  } else {
+    res.send('\nINTERNAL SERVER ERROR:\n')
+  }
+  res.end(err.toString())
 })
 
 app.listen(8080)

--- a/languages/java.js
+++ b/languages/java.js
@@ -1,17 +1,28 @@
 const Language = require('../language')
-const spawn = require('child_process').spawn
 
-module.exports = new Language(function (environment, container, out) {
-  var args = ['run']
+const Dockerode = require('dockerode')
+const docker = new Dockerode()
+
+module.exports = new Language(function (environment, container, out, onErr) {
+  var env = []
   for (var variable in environment) {
     if (environment.hasOwnProperty(variable)) {
-      args.push('-e')
-      args.push(variable + '=' + environment[variable])
+      env.push(variable + '=' + environment[variable])
     }
   }
-  console.log(args)
-  args.push('signumc/signumd-runner:java')
-  var child = spawn('docker', args)
-  child.stdout.pipe(out)
-  child.stderr.pipe(out)
+  docker.createContainer({Image: 'signumc/signumd-runner:java', Cmd: '/app/run.sh', Tty: false, Env: env}, function (err, container) {
+    if (err != null) return onErr(err)
+    container.start(function (err, data) {
+      if (err != null) return onErr(err)
+    })
+    container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
+      if (err != null) return onErr(err)
+      stream.pipe(out)
+    })
+    setTimeout(function () {
+      container.kill({}, function (err) {
+        if (err != null) return onErr(err)
+      })
+    }, 5000)
+  })
 })

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/ID10T-Errors/signumd#readme",
   "dependencies": {
     "body-parser": "^1.14.2",
+    "dockerode": "^2.2.8",
     "express": "^4.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Commit message:

Instead of just calling Docker commands, this commit causes the app to use a
faster and more reliable way of directly connecting to the Docker daemon and
sending commands to it instead of through the CLI. This allows us to easily
see what is happening when an image is created.

This commit also adds a 5s timeout to any running containers, preventing CPU
maxing out by students for a prolonged period of time.
